### PR TITLE
(Chore) Rename config prop

### DIFF
--- a/acc.config.json
+++ b/acc.config.json
@@ -32,6 +32,7 @@
     "privacy": "https://www.amsterdam.nl/privacy/"
   },
   "map": {
+    "municipality": "weesp",
     "tiles": {
       "args": ["https://{s}.data.amsterdam.nl/topo_rd/{z}/{x}/{y}.png"],
       "options": {

--- a/prod.config.json
+++ b/prod.config.json
@@ -32,6 +32,7 @@
     "privacy": "https://www.amsterdam.nl/privacy/"
   },
   "map": {
+    "municipality": "weesp",
     "tiles": {
       "args": ["https://{s}.data.amsterdam.nl/topo_rd/{z}/{x}/{y}.png"],
       "options": {


### PR DESCRIPTION
This PR adds a prop `municipality` to the `map` configuration in preparation of merging https://github.com/Amsterdam/signals-frontend/pull/985.

Since the config prop has been renamed and moved, the `gemeentenaam` prop has to be removed after the `signals-frontend` PR has been merged.